### PR TITLE
CI: raise full master-only test timeout to 30m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: test (full, skip concurrent, master only)
         if: github.ref == 'refs/heads/master'
-        run: go test -count=1 -skip TestDeriveGaloisKeysConcurrent ./...
+        run: go test -count=1 -timeout 30m -skip TestDeriveGaloisKeysConcurrent ./...
 
       - name: test (concurrent with race, full, master only)
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Summary

One-line follow-up to #15. The 'test (full, skip concurrent, master only)' step hit the default 10-min go test timeout on the #15 merge: run 24595971483, kgplus failed at 600.346s mid-Derive in TestDeriveGaloisKeys.

TestDeriveGaloisKeys (non-race) iterates LogN=14/15/16 on master. LogN=16 kgplus alone is ~450s on a 4-core ubuntu-latest runner; plus the smaller scenarios and other fixture tests in the package, 10 min is too tight.

The race-enabled steps got -timeout 30m in c36f33c; this step was an oversight.

## Test plan

- [ ] CI on this PR passes
- [ ] After merge, master CI succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)